### PR TITLE
[iOS] handle token generation for other login plugins that use cleeng

### DIFF
--- a/CleengLogin.podspec
+++ b/CleengLogin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'CleengLogin'
-  s.version      = '2.3.0'
+  s.version      = '2.3.1'
   s.summary      = 'Cleeng login plugin'
   s.license      = 'MIT'
   s.homepage     = 'https://github.com/applicaster/zapp-login-plugin-cleeng'

--- a/iOS/CleengLogin/CleengAPI.swift
+++ b/iOS/CleengLogin/CleengAPI.swift
@@ -21,6 +21,7 @@ enum CleengAPI {
                       receiptData: Data, isRestored: Bool)
     case purchaseItemUsingCode(offerId: String, token: String, reedeemCode: String)
     case restore(receipts: [RestorePurchaseData], token: String, receipt: String)
+    case generateCustomerToken(email: String)
 }
     
 extension CleengAPI {
@@ -44,6 +45,9 @@ extension CleengAPI {
             return "subscription"
         case .restore:
             return "restoreSubscriptions"
+        case .generateCustomerToken:
+            return "generateCustomerToken"
+            
         }
     }
     
@@ -120,6 +124,8 @@ extension CleengAPI {
                     "receipts": receipts,
                     "token": userToken,
                     "receiptData": receipt]
+        case .generateCustomerToken(let email):
+            return ["email": email]
         }
     }
 }

--- a/iOS/CleengLogin/CleengNetworkHandler.swift
+++ b/iOS/CleengLogin/CleengNetworkHandler.swift
@@ -24,7 +24,7 @@ class CleengNetworkHandler {
         isPerformingAuthorizationFlow = true
 
         switch apiRequest {
-        case .login, .loginWithFacebook, .register, .registerWithFacebook:
+        case .login, .loginWithFacebook, .register, .registerWithFacebook, .generateCustomerToken:
             performRequest(api: apiRequest) { (result) in
                 self.isPerformingAuthorizationFlow = false
                 


### PR DESCRIPTION
- the applicaster-cleeng web service supports a method to create a token for an existing customer, without a password
- this is required for login plugins that use cleeng only for purchases without login
- for example the digicell login plugin has its own auth system but works with cleeng to allow the user subscribe to an offer